### PR TITLE
Fix: stroke-width interpreted as <svg> width

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,9 +9,9 @@ var utils   = require('./utils');
 var BUFFER_SIZE     = 8;
 var DETECTOR        = /^\s*</;
 var ROOT_MATCHER    = /<svg\s[^>]+>/;
-var WIDTH_MATCHER   = /\bwidth=(['"])([^%]+?)\1/;
-var HEIGHT_MATCHER  = /\bheight=(['"])([^%]+?)\1/;
-var VIEWBOX_MATCHER = /\bviewBox=(['"])(.+?)\1/;
+var WIDTH_MATCHER   = /\swidth=(['"])([^%]+?)\1/;
+var HEIGHT_MATCHER  = /\sheight=(['"])([^%]+?)\1/;
+var VIEWBOX_MATCHER = /\sviewBox=(['"])(.+?)\1/;
 
 function parseViewbox (viewbox) {
   var bounds = viewbox.split(' ');

--- a/test/fixtures/svg/100x60.stroke-width.svg
+++ b/test/fixtures/svg/100x60.stroke-width.svg
@@ -1,0 +1,4 @@
+<!-- View box and (ignored) stroke-width -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60" stroke-width="2">
+  <ellipse cx="50" cy="30" rx="50" ry="30"/>
+</svg>


### PR DESCRIPTION
A `stroke-width` attribute on the `<svg>` element was incorrectly picked up and parsed as a `width`